### PR TITLE
Fix/comments 27 12 23

### DIFF
--- a/src/AuthApp.tsx
+++ b/src/AuthApp.tsx
@@ -19,7 +19,7 @@ const AuthApp = () => {
 
   return (
     <ApolloProvider client={client}>
-      <Layout style={{ minHeight: "100%" }}>
+      <Layout style={{ minHeight: "100vh" }}>
         <Layout.Header
           style={{
             display: "flex",

--- a/src/hooks/useErrorHandler.ts
+++ b/src/hooks/useErrorHandler.ts
@@ -1,6 +1,10 @@
-const useErrorHandler = () => (e: unknown) => {
-  console.error(e);
-  console.log(JSON.stringify(e));
+import { useCallback } from "react";
+
+const useErrorHandler = () => {
+  return useCallback((e: unknown) => {
+    console.error(e);
+    console.log(JSON.stringify(e));
+  }, []);
 };
 
 export default useErrorHandler;

--- a/src/pages/index/page.css
+++ b/src/pages/index/page.css
@@ -1,0 +1,4 @@
+.repo-list .ant-spin {
+  top: auto !important;
+  bottom: 0;
+}

--- a/src/pages/index/page.css
+++ b/src/pages/index/page.css
@@ -2,3 +2,9 @@
   top: auto !important;
   bottom: 0;
 }
+
+.repo-list .ant-list-item-action {
+  width: 130px;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/pages/index/page.tsx
+++ b/src/pages/index/page.tsx
@@ -58,6 +58,7 @@ const IndexPage = () => {
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<Search_QueryQuery | null>(null);
   const onError = useErrorHandler();
+  const [searchId, setSearchId] = useState(0);
 
   useEffect(() => {
     if (!q) {
@@ -65,6 +66,8 @@ const IndexPage = () => {
     }
 
     setLoading(true);
+
+    const startTime = new Date().getTime();
 
     client
       .query({
@@ -76,8 +79,16 @@ const IndexPage = () => {
       })
       .then((d) => setData(d.data))
       .catch(onError)
-      .finally(() => setLoading(false));
-  }, [client, count, onError, q]);
+      .finally(async () => {
+        await new Promise<void>((resolve) =>
+          setTimeout(
+            resolve,
+            Math.max(0, 400 - (new Date().getTime() - startTime))
+          )
+        );
+        setLoading(false);
+      });
+  }, [client, count, onError, q, searchId]);
 
   const hasMore =
     !data ||
@@ -95,7 +106,7 @@ const IndexPage = () => {
         >
           <Input.Search
             onSearch={(value) => {
-              setData(null);
+              setSearchId(new Date().getTime());
               setCount(10);
               setQ(value);
             }}

--- a/src/pages/index/page.tsx
+++ b/src/pages/index/page.tsx
@@ -18,6 +18,8 @@ import { StarFilled } from "@ant-design/icons";
 import { formatLink } from "../../util/router";
 import useErrorHandler from "../../hooks/useErrorHandler";
 
+import "./page.css";
+
 const IconText = ({ icon, text }: { icon: React.FC; text: string }) => (
   <Space>
     {createElement(icon)}
@@ -112,6 +114,7 @@ const IndexPage = () => {
           <div style={{ textAlign: "center" }}>
             <Button
               type="primary"
+              loading={loading}
               style={{
                 margin: "20px auto",
                 display: data && hasMore ? "block" : "none",
@@ -123,9 +126,9 @@ const IndexPage = () => {
           </div>
         }
         endMessage={<Divider plain>It is all, nothing more 🤐</Divider>}
-        scrollableTarget="scrollableDiv"
       >
         <List<Repository>
+          className={"repo-list"}
           loading={loading}
           itemLayout="horizontal"
           dataSource={(data?.search.nodes as Repository[]) || []}

--- a/src/pages/repo/header.tsx
+++ b/src/pages/repo/header.tsx
@@ -16,19 +16,46 @@ const RepoHeader = ({
   commitDate,
 }: RepoHeaderProps) => {
   return (
-    <Space style={{ justifyContent: "space-between", width: "100%" }}>
-      <Space>
-        <Avatar src={avatar} />
+    <div
+      style={{
+        justifyContent: "space-between",
+        width: "100%",
+        whiteSpace: "nowrap",
+        display: "flex",
+        alignItems: "center",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          gap: "7px",
+          alignItems: "center",
+          maxWidth: "calc(100% - 200px)",
+        }}
+      >
+        <Avatar src={avatar} style={{ flex: 1, maxWidth: "30px" }} />
         <Typography.Text>{login}</Typography.Text>
-        <Typography.Text type="secondary">{commitMessage}</Typography.Text>
-      </Space>
-      <Space>
+        <Typography.Text
+          type="secondary"
+          style={{ overflow: "hidden", flex: 1, textOverflow: "ellipsis" }}
+          title={commitMessage}
+        >
+          {commitMessage}
+        </Typography.Text>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: "7px",
+          alignItems: "center",
+        }}
+      >
         <Typography.Text code>{commitHash.substring(0, 8)}</Typography.Text>
         <Typography.Text type="secondary">
           {moment(commitDate).fromNow()}
         </Typography.Text>
-      </Space>
-    </Space>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/repo/page.tsx
+++ b/src/pages/repo/page.tsx
@@ -121,11 +121,9 @@ const RepoPage = () => {
         title: chunk,
         href: `${baseRepoHref}/${
           index === chunks.length - 1 ? "blob" : "tree"
-        }/${encodeURIComponent(refName)}/${
-          curPath ? curPath + "/" : ""
-        }${chunk}`,
+        }/${encodeURIComponent(refName)}/${curPath}${chunk}`,
       });
-      curPath += chunk;
+      curPath += chunk + "/";
     }
     return pathChunks;
   }, [baseRepoHref, fullpath, refName]);


### PR DESCRIPTION
Доработки по замечаниям от компании:

<blockquote>
К выполнененному заданию есть замечения, которые хотелось бы увидеть исправленными:
1. При просмотре репозитория с большим описанием, плывет верстка в описании репозитория. 
2. В поиске репозитория, если после загрузки нажать на search, не загружаются никакие данные, при этом нет отображения об ошибке. Оно появляется только если ввести текст, а потом удалить

Вот так выглядит после нажатия search button сразу после загрузки. Ожидаемое поведение или загрузка данных, или сообщение об ошибке
Вот так выглядит если ввести строку поиска, а потом ее удалить

3. Иногда breadcrumbs ломаются, как минимум один сценарий их поломки я смог воспроизвести стабильно. Ожидаемое поведение - навигация по breadcrumbs работает


Также привожу список замечаний, оставлю его на ваше усмотрение: 

1. Spinner лоадера загрузки при поиске репозиториев, привязан к началу страницы, поэтому его не видно после второго и более нажатия “load more”
2. В списоке найденных репозиториев, иконка “star” так и просит выравнивания, возможно вместе с числом “звезд”
</blockquote>

